### PR TITLE
plotCurve now handles NA in pseudotime column

### DIFF
--- a/R/plotCurve.R
+++ b/R/plotCurve.R
@@ -67,7 +67,7 @@ plotCurve <- function(gene.vec,
 
 
   dat <- mapply(X = gene.vec, Y = model.fit, function(X, Y) {
-    count_mat %>% dplyr::filter(gene ==  X) %>% dplyr::mutate(fitted = predict(Y, type = "response"))
+    count_mat %>% dplyr::filter(gene ==  X) %>% dplyr::filter(!is.na(pseudotime)) %>% dplyr::mutate(fitted = predict(Y, type = "response"))
   }, SIMPLIFY = FALSE)
 
 


### PR DESCRIPTION
Running slingshot on large datasets often results in multiple lineages. 

Not all cells are part of all lineages, and consequently some cells have an 'NA' for a given lineage as their pseudotime. This would cause an error when plotting the curve. 
A simple filtering step solves this problem.