### PR TITLE
Correct count matrices compatibility and consolidate tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Suggests:
     rmarkdown,
     SingleCellExperiment,
     irlba,
+    SeuratObject,
     scales,
     slingshot,
     BiocStyle,

--- a/R/PseudotimeDE.R
+++ b/R/PseudotimeDE.R
@@ -76,6 +76,9 @@ pseudotimeDE <- function(gene,
   #   }
   # }
 
+  if(length(knots) != k){
+    stop("The number of knot positions given (",length(knots),") does not match k.")
+  }
 
 
   ## Construct formula

--- a/R/runPseudotimeDE.R
+++ b/R/runPseudotimeDE.R
@@ -75,11 +75,11 @@ runPseudotimeDE <- function(gene.vec,
     cur_res <- tryCatch(expr = pseudotimeDE(gene = x,
                                             ori.tbl = ori.tbl,
                                             sub.tbl = sub.tbl,
-                                            mat = mat[x,],
+                                            mat = mat,
                                             model = model,
                                             assay.use = assay.use,
                                             seurat.assay = seurat.assay) |>
-        append(stats::setNames("NA_character_", "notes")), #input only the target gene
+        append(stats::setNames("NA_character_", "notes")),
                         error = function(e) {
                           list(fix.pv = NA,
                                emp.pv = NA,

--- a/R/runPseudotimeDE.R
+++ b/R/runPseudotimeDE.R
@@ -77,6 +77,12 @@ runPseudotimeDE <- function(gene.vec,
                                             sub.tbl = sub.tbl,
                                             mat = mat,
                                             model = model,
+                                            k = k,
+                                            knots = knots,
+                                            fix.weight = fix.weight,
+                                            aicdiff = aicdiff,
+                                            quant = quant,
+                                            usebam = usebam,
                                             assay.use = assay.use,
                                             seurat.assay = seurat.assay) |>
         append(stats::setNames("NA_character_", "notes")),
@@ -97,14 +103,6 @@ runPseudotimeDE <- function(gene.vec,
                         })
     cur_res
   },
-  assay.use = assay.use,
-  k = k,
-  knots = knots,
-  fix.weight = fix.weight,
-  aicdiff = aicdiff,
-  quant = quant,
-  usebam = usebam,
-  seurat.assay = seurat.assay,
   BPPARAM = BPPARAM)
 
 

--- a/R/runPseudotimeDE.R
+++ b/R/runPseudotimeDE.R
@@ -57,7 +57,7 @@ runPseudotimeDE <- function(gene.vec,
   set.seed(seed)
 
   # Avoid package check error
-  expv.quantile <- gam.fit <- NULL
+  notes <- expv.quantile <- gam.fit <- NULL
 
   BPPARAM <- BiocParallel::bpparam()
   BPPARAM$workers <- mc.cores
@@ -78,7 +78,8 @@ runPseudotimeDE <- function(gene.vec,
                                             mat = mat[x,],
                                             model = model,
                                             assay.use = assay.use,
-                                            seurat.assay = seurat.assay), #input only the target gene
+                                            seurat.assay = seurat.assay) |>
+        append(stats::setNames("NA_character_", "notes")), #input only the target gene
                         error = function(e) {
                           list(fix.pv = NA,
                                emp.pv = NA,
@@ -91,7 +92,8 @@ runPseudotimeDE <- function(gene.vec,
                                aic = NA,
                                expv.quantile = NA,
                                expv.mean = NA,
-                               expv.zero = NA)
+                               expv.zero = NA,
+                               notes = e)
                         })
     cur_res
   },
@@ -111,7 +113,7 @@ runPseudotimeDE <- function(gene.vec,
     res <- t(res)
     rownames(res) <- gene.vec
     res <- tibble::as_tibble(res, rownames = "gene")
-    res <- tidyr::unnest(res, cols = ! (gam.fit | expv.quantile))
+    res <- tidyr::unnest(res, cols = ! (gam.fit | expv.quantile | notes))
   }
 
   res

--- a/tests/testthat/test-PseudotimeDE.R
+++ b/tests/testthat/test-PseudotimeDE.R
@@ -113,3 +113,54 @@ test_that("runPseudotimeDE works with matrix input", {
                   "error")
 })
 
+
+test_that("We can change parameters", {
+  data("LPS_sce")
+  data("LPS_ori_tbl")
+  data("LPS_sub_tbl")
+  
+  res_k6 <- PseudotimeDE::pseudotimeDE(gene = "CCL5",
+                                       ori.tbl = LPS_ori_tbl,
+                                       sub.tbl = LPS_sub_tbl[1:100],
+                                       mat = LPS_sce,
+                                       model = "nb")
+  
+  expect_identical(as.character(formula(res_k6$gam.fit))[[3]],
+                   's(pseudotime, k = 6, bs = "cr")')
+  
+  res_k7 <- PseudotimeDE::pseudotimeDE(gene = "CCL5",
+                                       ori.tbl = LPS_ori_tbl,
+                                       sub.tbl = LPS_sub_tbl[1:100],
+                                       mat = LPS_sce,
+                                       model = "nb",
+                                       k = 7,
+                                       knots = c(0:6/6))
+  
+  expect_identical(as.character(formula(res_k7$gam.fit))[[3]],
+                   's(pseudotime, k = 7, bs = "cr")')
+  
+  res_run_k6 <- PseudotimeDE::runPseudotimeDE(gene.vec = c("CCL5", "CXCL10", "JustAJoke"),
+                                              ori.tbl = LPS_ori_tbl,
+                                              sub.tbl = LPS_sub_tbl[1:100],
+                                              mat = LPS_sce,
+                                              model = "auto",
+                                              mc.cores = 1)
+  
+  expect_identical(as.character(formula(res_run_k6$gam.fit[[1]]))[[3]],
+                   's(pseudotime, k = 6, bs = "cr")')
+  
+  
+  res_run_k7 <- PseudotimeDE::runPseudotimeDE(gene.vec = c("CCL5", "CXCL10", "JustAJoke"),
+                                              ori.tbl = LPS_ori_tbl,
+                                              sub.tbl = LPS_sub_tbl[1:100],
+                                              mat = LPS_sce,
+                                              model = "auto",
+                                              k = 7,
+                                              knots = c(0:6/6),
+                                              mc.cores = 1)
+  
+  expect_identical(as.character(formula(res_run_k7$gam.fit[[1]]))[[3]],
+                   's(pseudotime, k = 7, bs = "cr")')
+  
+  
+})

--- a/tests/testthat/test-PseudotimeDE.R
+++ b/tests/testthat/test-PseudotimeDE.R
@@ -84,3 +84,32 @@ test_that("runPseudotimeDE works with Seurat object", {
   expect_contains(class(res_seurat$notes[[3]]),
                   "error")
 })
+
+
+test_that("runPseudotimeDE works with matrix input", {
+  data("LPS_sce")
+  data("LPS_ori_tbl")
+  data("LPS_sub_tbl")
+  
+  LPS_count_mat <- SingleCellExperiment::counts(LPS_sce)
+  
+  res_sce <- runPseudotimeDE(gene.vec = c("CCL5", "CXCL10", "JustAJoke"),
+                             ori.tbl = LPS_ori_tbl,
+                             sub.tbl = LPS_sub_tbl[1:100],
+                             mat = LPS_sce,
+                             model = "nb",
+                             mc.cores = 1)
+  
+  
+  res_count_mat <- runPseudotimeDE(gene.vec = c("CCL5", "CXCL10", "JustAJoke"),
+                                   ori.tbl = LPS_ori_tbl,
+                                   sub.tbl = LPS_sub_tbl[1:100],
+                                   mat = LPS_count_mat,
+                                   model = "nb",
+                                   mc.cores = 1)
+  
+  expect_equal(res_sce[1:2, ], res_count_mat[1:2, ])
+  expect_contains(class(res_count_mat$notes[[3]]),
+                  "error")
+})
+

--- a/tests/testthat/test-PseudotimeDE.R
+++ b/tests/testthat/test-PseudotimeDE.R
@@ -12,6 +12,7 @@ test_that("PseudotimeDE works", {
                                     mat = LPS_sce,
                                     model = "nb")
   expect_equal(length(res1), 12)
+  expect_false(is.na(res1$test.statistics))
 
   res2 <- PseudotimeDE::pseudotimeDE(gene = "CCL5",
                                     ori.tbl = LPS_ori_tbl,
@@ -19,13 +20,21 @@ test_that("PseudotimeDE works", {
                                     mat = LPS_sce,
                                     model = "auto")
   expect_equal(length(res2), 12)
+  expect_false(is.na(res2$test.statistic))
 
   res3 <- PseudotimeDE::runPseudotimeDE(gene.vec = c("CCL5", "CXCL10", "JustAJoke"),
                                      ori.tbl = LPS_ori_tbl,
                                      sub.tbl = LPS_sub_tbl[1:100],
                                      mat = LPS_sce,
-                                     model = "auto")
+                                     model = "auto",
+                                     mc.cores = 1)
+  
   expect_equal(dim(res3)[1], 3)
+  expect_false( any(is.na(res3$test.statistics[1:2])) )
+  expect_true( is.na(res3$test.statistics[[3]]) )
+  expect_contains(class( res3$notes[[3]] ),
+                  "error")
+  
 
   res4 <- PseudotimeDE::plotCurve(gene.vec = c("CCL5", "CXCL10"),
                                         ori.tbl = LPS_ori_tbl,
@@ -37,3 +46,4 @@ test_that("PseudotimeDE works", {
                                         sub.tbl = LPS_sub_tbl[1:100])
   expect_equal(class(res5)[1], "gg")
 })
+

--- a/tests/testthat/test-PseudotimeDE.R
+++ b/tests/testthat/test-PseudotimeDE.R
@@ -47,3 +47,40 @@ test_that("PseudotimeDE works", {
   expect_equal(class(res5)[1], "gg")
 })
 
+
+test_that("runPseudotimeDE works with Seurat object", {
+  data("LPS_sce")
+  data("LPS_ori_tbl")
+  data("LPS_sub_tbl")
+  
+  requireNamespace("Seurat")
+  
+  suppressWarnings(
+    LPS_seurat <- SeuratObject::as.Seurat(LPS_sce) |>
+      SeuratObject::RenameAssays(assay.name = "originalexp",
+                                 new.assay.name = "RNA")
+  )
+  
+  
+  res_sce <- runPseudotimeDE(gene.vec = c("CCL5", "CXCL10", "JustAJoke"),
+                             ori.tbl = LPS_ori_tbl,
+                             sub.tbl = LPS_sub_tbl[1:100],
+                             mat = LPS_sce,
+                             model = "nb",
+                             mc.cores = 1)
+  
+  
+  res_seurat <- runPseudotimeDE(gene.vec = c("CCL5", "CXCL10", "JustAJoke"),
+                                ori.tbl = LPS_ori_tbl,
+                                sub.tbl = LPS_sub_tbl[1:100],
+                                mat = LPS_seurat,
+                                model = "nb",
+                                mc.cores = 1)
+  
+  stable_colnames <- c("fix.pv", "emp.pv", "rank", "test.statistics", "aic", "expv.mean", "expv.zero")
+  
+  expect_equal(res_sce[1:2, stable_colnames],
+               res_seurat[1:2, stable_colnames])
+  expect_contains(class(res_seurat$notes[[3]]),
+                  "error")
+})


### PR DESCRIPTION
In tests, all tests use mc.cores = 1 as on my Windows computer I kept getting surprising failures.

Changes:
* `runPseudotimeDE` returns an additional column "notes", which contains error messages (or NA), this helps for debugging.
* added tests, especially for Seurat objects
* revert the change in 0d57 (enhance Seurat compatibility) that subsets the matrix in `runPseudotimeDE` before sending to `pseudotimeDE`: this does not seem necessary for Seurat objects but breaks when using count matrices (since we don't use `[,,drop=FALSE]`).
* in my hands changes to parameters such `k` when calling `runPseudotimeDE` are not properly transmitted to `pseudotimeDE`, even though they should be in the `...` argument of `bplapply`. Solved by adding as explicit arguments of the `pseudotimeDE` call.