### PR TITLE
Custom bs argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Suggests:
     rmarkdown,
     SingleCellExperiment,
     irlba,
+    SeuratObject,
     scales,
     slingshot,
     BiocStyle,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,8 +41,8 @@ Suggests:
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-LazyDataCompression:xz
-RoxygenNote: 7.2.3
+LazyDataCompression: xz
+RoxygenNote: 7.3.1
 VignetteBuilder: knitr
 URL: https://github.com/SONGDONGYUAN1994/PseudotimeDE
 BugReports: https://github.com/SONGDONGYUAN1994/PseudotimeDE/issues

--- a/R/PseudotimeDE.R
+++ b/R/PseudotimeDE.R
@@ -76,6 +76,9 @@ pseudotimeDE <- function(gene,
   #   }
   # }
 
+  if(length(knots) != k){
+    stop("The number of knot positions given (",length(knots),") does not match k.")
+  }
 
 
   ## Construct formula

--- a/R/runPseudotimeDE.R
+++ b/R/runPseudotimeDE.R
@@ -75,11 +75,11 @@ runPseudotimeDE <- function(gene.vec,
     cur_res <- tryCatch(expr = pseudotimeDE(gene = x,
                                             ori.tbl = ori.tbl,
                                             sub.tbl = sub.tbl,
-                                            mat = mat[x,],
+                                            mat = mat,
                                             model = model,
                                             assay.use = assay.use,
                                             seurat.assay = seurat.assay) |>
-        append(stats::setNames("NA_character_", "notes")), #input only the target gene
+        append(stats::setNames("NA_character_", "notes")),
                         error = function(e) {
                           list(fix.pv = NA,
                                emp.pv = NA,

--- a/R/runPseudotimeDE.R
+++ b/R/runPseudotimeDE.R
@@ -16,6 +16,7 @@
 #' @param model A string of the model name. One of \code{nb}, \code{zinb}, \code{gaussian}, \code{auto} and \code{qgam}.
 #' @param k A integer of the basis dimension. Default is 6. The results are usually robust to different k; we recommend to use k from 5 to 10.
 #' @param knots A numeric vector of the location of knots. Default is evenly distributed between 0 to 1. For instance, if your k = 6, and your range is [0, 10], then the position of knots should be \code{c(0:5)*(10-0)}.
+#' @param bs A string indicating the spline smoothing basis. See \code{?mgcv::smooth.terms} for available options.
 #' @param fix.weight A logic variable indicating if the ZINB-GAM will use the zero weights from the original model.
 #' @param aicdiff A numeric variable of the threshold of model selection. Only works when \code{model = `auto`}.
 #' @param seed A numeric variable of the random seed. It mainly affects the fitting of null distribution.
@@ -45,6 +46,7 @@ runPseudotimeDE <- function(gene.vec,
                             model = c("nb", "zinb", "gaussian", "auto", "qgam"),
                             k = 6,
                             knots = c(0:5/5),
+                            bs = "cr",
                             fix.weight = TRUE,
                             aicdiff = 10,
                             seed = 123,
@@ -79,6 +81,7 @@ runPseudotimeDE <- function(gene.vec,
                                             model = model,
                                             k = k,
                                             knots = knots,
+                                            bs = bs,
                                             fix.weight = fix.weight,
                                             aicdiff = aicdiff,
                                             quant = quant,

--- a/R/runPseudotimeDE.R
+++ b/R/runPseudotimeDE.R
@@ -77,6 +77,12 @@ runPseudotimeDE <- function(gene.vec,
                                             sub.tbl = sub.tbl,
                                             mat = mat,
                                             model = model,
+                                            k = k,
+                                            knots = knots,
+                                            fix.weight = fix.weight,
+                                            aicdiff = aicdiff,
+                                            quant = quant,
+                                            usebam = usebam,
                                             assay.use = assay.use,
                                             seurat.assay = seurat.assay) |>
         append(stats::setNames("NA_character_", "notes")),
@@ -97,14 +103,6 @@ runPseudotimeDE <- function(gene.vec,
                         })
     cur_res
   },
-  assay.use = assay.use,
-  k = k,
-  knots = knots,
-  fix.weight = fix.weight,
-  aicdiff = aicdiff,
-  quant = quant,
-  usebam = usebam,
-  seurat.assay = seurat.assay,
   BPPARAM = BPPARAM)
 
 

--- a/R/runPseudotimeDE.R
+++ b/R/runPseudotimeDE.R
@@ -57,7 +57,7 @@ runPseudotimeDE <- function(gene.vec,
   set.seed(seed)
 
   # Avoid package check error
-  expv.quantile <- gam.fit <- NULL
+  notes <- expv.quantile <- gam.fit <- NULL
 
   BPPARAM <- BiocParallel::bpparam()
   BPPARAM$workers <- mc.cores
@@ -78,7 +78,8 @@ runPseudotimeDE <- function(gene.vec,
                                             mat = mat[x,],
                                             model = model,
                                             assay.use = assay.use,
-                                            seurat.assay = seurat.assay), #input only the target gene
+                                            seurat.assay = seurat.assay) |>
+        append(stats::setNames("NA_character_", "notes")), #input only the target gene
                         error = function(e) {
                           list(fix.pv = NA,
                                emp.pv = NA,
@@ -91,7 +92,8 @@ runPseudotimeDE <- function(gene.vec,
                                aic = NA,
                                expv.quantile = NA,
                                expv.mean = NA,
-                               expv.zero = NA)
+                               expv.zero = NA,
+                               notes = e)
                         })
     cur_res
   },
@@ -111,7 +113,7 @@ runPseudotimeDE <- function(gene.vec,
     res <- t(res)
     rownames(res) <- gene.vec
     res <- tibble::as_tibble(res, rownames = "gene")
-    res <- tidyr::unnest(res, cols = ! (gam.fit | expv.quantile))
+    res <- tidyr::unnest(res, cols = ! (gam.fit | expv.quantile | notes))
   }
 
   res

--- a/man/pseudotimeDE.Rd
+++ b/man/pseudotimeDE.Rd
@@ -13,6 +13,7 @@ pseudotimeDE(
   model = c("nb", "zinb", "gaussian", "auto", "qgam"),
   k = 6,
   knots = c(0:5/5),
+  bs = "cr",
   fix.weight = TRUE,
   aicdiff = 10,
   seed = 123,
@@ -41,6 +42,8 @@ Its row names should be genes and col names should be cells.}
 \item{k}{A integer of the basis dimension. Default is 6. The reults are usually robust to different k; we recommend to use k from 5 to 10.}
 
 \item{knots}{A numeric vector of the location of knots. Default is evenly distributed between 0 to 1. For instance, if your k = 6, and your range is [0, 10], then the position of knots should be \code{c(0:5)*(10-0)}.}
+
+\item{bs}{A string indicating the spline smoothing basis. See \code{?mgcv::smooth.terms} for available options.}
 
 \item{fix.weight}{A logic variable indicating if the ZINB-GAM will use the zero weights from the original model. Used for saving time since ZINB-GAM is computationally intense.}
 

--- a/man/runPseudotimeDE.Rd
+++ b/man/runPseudotimeDE.Rd
@@ -13,6 +13,7 @@ runPseudotimeDE(
   model = c("nb", "zinb", "gaussian", "auto", "qgam"),
   k = 6,
   knots = c(0:5/5),
+  bs = "cr",
   fix.weight = TRUE,
   aicdiff = 10,
   seed = 123,
@@ -44,6 +45,8 @@ Its row names should be genes and col names should be cells.}
 \item{k}{A integer of the basis dimension. Default is 6. The results are usually robust to different k; we recommend to use k from 5 to 10.}
 
 \item{knots}{A numeric vector of the location of knots. Default is evenly distributed between 0 to 1. For instance, if your k = 6, and your range is [0, 10], then the position of knots should be \code{c(0:5)*(10-0)}.}
+
+\item{bs}{A string indicating the spline smoothing basis. See \code{?mgcv::smooth.terms} for available options.}
 
 \item{fix.weight}{A logic variable indicating if the ZINB-GAM will use the zero weights from the original model.}
 

--- a/tests/testthat/test-PseudotimeDE.R
+++ b/tests/testthat/test-PseudotimeDE.R
@@ -113,3 +113,54 @@ test_that("runPseudotimeDE works with matrix input", {
                   "error")
 })
 
+
+test_that("We can change parameters", {
+  data("LPS_sce")
+  data("LPS_ori_tbl")
+  data("LPS_sub_tbl")
+  
+  res_k6 <- PseudotimeDE::pseudotimeDE(gene = "CCL5",
+                                       ori.tbl = LPS_ori_tbl,
+                                       sub.tbl = LPS_sub_tbl[1:100],
+                                       mat = LPS_sce,
+                                       model = "nb")
+  
+  expect_identical(as.character(formula(res_k6$gam.fit))[[3]],
+                   's(pseudotime, k = 6, bs = "cr")')
+  
+  res_k7 <- PseudotimeDE::pseudotimeDE(gene = "CCL5",
+                                       ori.tbl = LPS_ori_tbl,
+                                       sub.tbl = LPS_sub_tbl[1:100],
+                                       mat = LPS_sce,
+                                       model = "nb",
+                                       k = 7,
+                                       knots = c(0:6/6))
+  
+  expect_identical(as.character(formula(res_k7$gam.fit))[[3]],
+                   's(pseudotime, k = 7, bs = "cr")')
+  
+  res_run_k6 <- PseudotimeDE::runPseudotimeDE(gene.vec = c("CCL5", "CXCL10", "JustAJoke"),
+                                              ori.tbl = LPS_ori_tbl,
+                                              sub.tbl = LPS_sub_tbl[1:100],
+                                              mat = LPS_sce,
+                                              model = "auto",
+                                              mc.cores = 1)
+  
+  expect_identical(as.character(formula(res_run_k6$gam.fit[[1]]))[[3]],
+                   's(pseudotime, k = 6, bs = "cr")')
+  
+  
+  res_run_k7 <- PseudotimeDE::runPseudotimeDE(gene.vec = c("CCL5", "CXCL10", "JustAJoke"),
+                                              ori.tbl = LPS_ori_tbl,
+                                              sub.tbl = LPS_sub_tbl[1:100],
+                                              mat = LPS_sce,
+                                              model = "auto",
+                                              k = 7,
+                                              knots = c(0:6/6),
+                                              mc.cores = 1)
+  
+  expect_identical(as.character(formula(res_run_k7$gam.fit[[1]]))[[3]],
+                   's(pseudotime, k = 7, bs = "cr")')
+  
+  
+})

--- a/tests/testthat/test-PseudotimeDE.R
+++ b/tests/testthat/test-PseudotimeDE.R
@@ -84,3 +84,32 @@ test_that("runPseudotimeDE works with Seurat object", {
   expect_contains(class(res_seurat$notes[[3]]),
                   "error")
 })
+
+
+test_that("runPseudotimeDE works with matrix input", {
+  data("LPS_sce")
+  data("LPS_ori_tbl")
+  data("LPS_sub_tbl")
+  
+  LPS_count_mat <- SingleCellExperiment::counts(LPS_sce)
+  
+  res_sce <- runPseudotimeDE(gene.vec = c("CCL5", "CXCL10", "JustAJoke"),
+                             ori.tbl = LPS_ori_tbl,
+                             sub.tbl = LPS_sub_tbl[1:100],
+                             mat = LPS_sce,
+                             model = "nb",
+                             mc.cores = 1)
+  
+  
+  res_count_mat <- runPseudotimeDE(gene.vec = c("CCL5", "CXCL10", "JustAJoke"),
+                                   ori.tbl = LPS_ori_tbl,
+                                   sub.tbl = LPS_sub_tbl[1:100],
+                                   mat = LPS_count_mat,
+                                   model = "nb",
+                                   mc.cores = 1)
+  
+  expect_equal(res_sce[1:2, ], res_count_mat[1:2, ])
+  expect_contains(class(res_count_mat$notes[[3]]),
+                  "error")
+})
+

--- a/tests/testthat/test-PseudotimeDE.R
+++ b/tests/testthat/test-PseudotimeDE.R
@@ -164,3 +164,94 @@ test_that("We can change parameters", {
   
   
 })
+
+
+test_that("We can change spline basis", {
+  data("LPS_sce")
+  data("LPS_ori_tbl")
+  data("LPS_sub_tbl")
+  
+  # just pseudotimeDE
+  
+  res_cr <- PseudotimeDE::pseudotimeDE(gene = "CCL5",
+                                       ori.tbl = LPS_ori_tbl,
+                                       sub.tbl = LPS_sub_tbl[1:100],
+                                       mat = LPS_sce,
+                                       model = "nb")
+  
+  expect_identical(as.character(formula(res_cr$gam.fit))[[3]],
+                   's(pseudotime, k = 6, bs = "cr")')
+  
+  res_cs <- PseudotimeDE::pseudotimeDE(gene = "CCL5",
+                                       ori.tbl = LPS_ori_tbl,
+                                       sub.tbl = LPS_sub_tbl[1:100],
+                                       mat = LPS_sce,
+                                       model = "nb",
+                                       bs = "cs")
+  
+  expect_identical(as.character(formula(res_cs$gam.fit))[[3]],
+                   's(pseudotime, k = 6, bs = "cs")')
+  
+  
+  
+  res_cc <- PseudotimeDE::pseudotimeDE(gene = "CCL5",
+                                       ori.tbl = LPS_ori_tbl,
+                                       sub.tbl = LPS_sub_tbl[1:100],
+                                       mat = LPS_sce,
+                                       model = "nb",
+                                       bs = "cc")
+  
+  expect_identical(as.character(formula(res_cc$gam.fit))[[3]],
+                   's(pseudotime, k = 6, bs = "cc")')
+  
+  
+  
+  # test runPseudotimeDE
+  
+  res_run_cr <- PseudotimeDE::runPseudotimeDE(gene.vec = c("CCL5", "CXCL10", "JustAJoke"),
+                                              ori.tbl = LPS_ori_tbl,
+                                              sub.tbl = LPS_sub_tbl[1:100],
+                                              mat = LPS_sce,
+                                              model = "auto",
+                                              mc.cores = 1)
+  
+  expect_identical(as.character(formula(res_run_cr$gam.fit[[1]]))[[3]],
+                   's(pseudotime, k = 6, bs = "cr")')
+  
+  
+  res_run_cs <- PseudotimeDE::runPseudotimeDE(gene.vec = c("CCL5", "CXCL10", "JustAJoke"),
+                                              ori.tbl = LPS_ori_tbl,
+                                              sub.tbl = LPS_sub_tbl[1:100],
+                                              mat = LPS_sce,
+                                              model = "auto",
+                                              bs = "cs",
+                                              mc.cores = 1)
+  
+  expect_identical(as.character(formula(res_run_cs$gam.fit[[1]]))[[3]],
+                   's(pseudotime, k = 6, bs = "cs")')
+  
+  expect_true(is.na( res_run_cs$test.statistics[[3]] ))
+  expect_identical(res_run_cr$expv.mean, res_run_cs$expv.mean)
+  
+  relative_diff <- (res_run_cr$test.statistics - res_run_cs$test.statistics)/res_run_cr$test.statistics
+  expect_true(all( relative_diff[1:2] < .1 ))
+  
+  
+  res_run_cc <- PseudotimeDE::runPseudotimeDE(gene.vec = c("CCL5", "CXCL10", "JustAJoke"),
+                                              ori.tbl = LPS_ori_tbl,
+                                              sub.tbl = LPS_sub_tbl[1:100],
+                                              mat = LPS_sce,
+                                              model = "auto",
+                                              bs = "cc",
+                                              mc.cores = 1)
+  
+  expect_identical(as.character(formula(res_run_cc$gam.fit[[1]]))[[3]],
+                   's(pseudotime, k = 6, bs = "cc")')
+  
+  expect_true(is.na( res_run_cc$test.statistics[[3]] ))
+  
+  expect_identical(res_run_cr$expv.mean, res_run_cc$expv.mean)
+  
+})
+
+

--- a/tests/testthat/test-PseudotimeDE.R
+++ b/tests/testthat/test-PseudotimeDE.R
@@ -12,6 +12,7 @@ test_that("PseudotimeDE works", {
                                     mat = LPS_sce,
                                     model = "nb")
   expect_equal(length(res1), 12)
+  expect_false(is.na(res1$test.statistics))
 
   res2 <- PseudotimeDE::pseudotimeDE(gene = "CCL5",
                                     ori.tbl = LPS_ori_tbl,
@@ -19,13 +20,21 @@ test_that("PseudotimeDE works", {
                                     mat = LPS_sce,
                                     model = "auto")
   expect_equal(length(res2), 12)
+  expect_false(is.na(res2$test.statistic))
 
   res3 <- PseudotimeDE::runPseudotimeDE(gene.vec = c("CCL5", "CXCL10", "JustAJoke"),
                                      ori.tbl = LPS_ori_tbl,
                                      sub.tbl = LPS_sub_tbl[1:100],
                                      mat = LPS_sce,
-                                     model = "auto")
+                                     model = "auto",
+                                     mc.cores = 1)
+  
   expect_equal(dim(res3)[1], 3)
+  expect_false( any(is.na(res3$test.statistics[1:2])) )
+  expect_true( is.na(res3$test.statistics[[3]]) )
+  expect_contains(class( res3$notes[[3]] ),
+                  "error")
+  
 
   res4 <- PseudotimeDE::plotCurve(gene.vec = c("CCL5", "CXCL10"),
                                         ori.tbl = LPS_ori_tbl,
@@ -37,3 +46,4 @@ test_that("PseudotimeDE works", {
                                         sub.tbl = LPS_sub_tbl[1:100])
   expect_equal(class(res5)[1], "gg")
 })
+

--- a/tests/testthat/test-PseudotimeDE.R
+++ b/tests/testthat/test-PseudotimeDE.R
@@ -47,3 +47,40 @@ test_that("PseudotimeDE works", {
   expect_equal(class(res5)[1], "gg")
 })
 
+
+test_that("runPseudotimeDE works with Seurat object", {
+  data("LPS_sce")
+  data("LPS_ori_tbl")
+  data("LPS_sub_tbl")
+  
+  requireNamespace("Seurat")
+  
+  suppressWarnings(
+    LPS_seurat <- SeuratObject::as.Seurat(LPS_sce) |>
+      SeuratObject::RenameAssays(assay.name = "originalexp",
+                                 new.assay.name = "RNA")
+  )
+  
+  
+  res_sce <- runPseudotimeDE(gene.vec = c("CCL5", "CXCL10", "JustAJoke"),
+                             ori.tbl = LPS_ori_tbl,
+                             sub.tbl = LPS_sub_tbl[1:100],
+                             mat = LPS_sce,
+                             model = "nb",
+                             mc.cores = 1)
+  
+  
+  res_seurat <- runPseudotimeDE(gene.vec = c("CCL5", "CXCL10", "JustAJoke"),
+                                ori.tbl = LPS_ori_tbl,
+                                sub.tbl = LPS_sub_tbl[1:100],
+                                mat = LPS_seurat,
+                                model = "nb",
+                                mc.cores = 1)
+  
+  stable_colnames <- c("fix.pv", "emp.pv", "rank", "test.statistics", "aic", "expv.mean", "expv.zero")
+  
+  expect_equal(res_sce[1:2, stable_colnames],
+               res_seurat[1:2, stable_colnames])
+  expect_contains(class(res_seurat$notes[[3]]),
+                  "error")
+})


### PR DESCRIPTION
This PR ("custom bs argument") and the next PR ("custom formula") are mutually exclusive, and may introduce too much complexity compared to the main version, feel free to reject them.

They are both extension to PR #22 .

Rationale: for the data I'm working with (periodic), there seems to be a benefit to using `cc` splines instead of `cr`. As this is hardcoded in the pseudotimeDE code, I made these changes to allow the user to customize the `bs` argument (this PR) or provide a completely custom formula (the next PR), which may be of use to some users.